### PR TITLE
Replace body with validated version

### DIFF
--- a/lib/expressroutes.js
+++ b/lib/expressroutes.js
@@ -36,7 +36,7 @@ function expressroutes(router, options) {
             validate = validator.validate;
 
             before.push(function validateInput(req, res, next) {
-                var value, isPath;
+                var value, isPath, isBody;
 
                 switch (parameter.in) {
                     case 'path':
@@ -49,6 +49,7 @@ function expressroutes(router, options) {
                         break;
                     case 'body':
                     case 'form':
+                        isBody = true;
                         value = req.body;
                 }
 
@@ -61,6 +62,10 @@ function expressroutes(router, options) {
 
                     if (isPath) {
                         req.params[parameter.name] = newvalue;
+                    }
+
+                    if (isBody) {
+                        req.body = newvalue;
                     }
 
                     next();


### PR DESCRIPTION
Related to: krakenjs/swaggerize-builder#28

After validation, the body may have changed.

For example, when using the enjoi settings:

    allowUnknown: true
    stripUnknown: true

Properties may be removed from the incoming request body.  This change
ensures the newly validated body is used instead of the original.